### PR TITLE
Composerise.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+	"name": "ptcinc/solr-php-client",
+	"description": "A purely PHP library for indexing and searching documents against an Apache Solr installation",
+	"keywords": ["php", "solr", "client"],
+	"license": "BSD-3-Clause",
+	"authors": [
+		{
+			"name": "Donovan Jimenez",
+			"homepage": "https://github.com/djimenez"
+		}
+	],
+	"autoload": {
+		"psr-0": {
+			"Apache_Solr_": ""
+		}
+	}
+}


### PR DESCRIPTION
Hi @djimenez thanks for prompt response on #3 , here is a composer.json file which will allow people to pull your module in as a dependency. It also provides autoloading, so they won't need to require files explicitly. I've left your require_once's in place to make it backwards-compatible with non-composerised use.

It would be good if you could also tag the module (`git tag 1.0.0 && git push origin --tags`). Semver is probably the most widespread these days, so proposing major-minor-patch (1.0.0).