### PR TITLE
Add method attribute for PHP 8.1 compatibility

### DIFF
--- a/Apache/Solr/Document.php
+++ b/Apache/Solr/Document.php
@@ -298,6 +298,7 @@ class Apache_Solr_Document implements IteratorAggregate
 	 * }
 	 * </code>
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator()
 	{
 		$arrayObject = new ArrayObject($this->_fields);


### PR DESCRIPTION
This fixes the following deprecation warning when running PHP 8.1

`Deprecated: Return type of Apache_Solr_Document::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/vendor/ptcinc/solr-php-client/Apache/Solr/Document.php on line 301`

You can read about this specific attribute here https://php.watch/versions/8.1/ReturnTypeWillChange

Could you please tag `v1.0.1` once this is merged.  Thanks.